### PR TITLE
Fix for 'Unknown encoding' error

### DIFF
--- a/bin/swiffer
+++ b/bin/swiffer
@@ -5,8 +5,8 @@ var swiffer  = require('../Swiffer'),
     template;
 
 try {
-  template = fs.readFileSync(templateName, {encoding: 'utf8'});
+  template = fs.readFileSync(templateName).toString('utf8');
+  swiffer.clean(template);
 } catch(err) {
   console.error(err);
 }
-swiffer.clean(template);


### PR DESCRIPTION
In Ubuntu 13.04, swiffer doesn't seem to be working out of the box.

1) When I executed the example, `bin/swiffer examples/jsControl.tl`, it failed with

```
[Error: Unknown encoding]
Cannot call method 'substr' of undefined
```

readFileSync returns a Buffer and it has a toString method which accepts encoding as one of the optional parameters. This seems to be working fine.

2) When readFileSync fails, we display error in the console and still trying to do 'clean'. If there is an error, we shouldn't do the cleaning. So moving the line which cleans to the try..catch block.
